### PR TITLE
Add h-card microformats

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,14 +1,14 @@
 <header class="site-header" role="banner">
-    <div class="header-container">
+    <div class="header-container h-card">
         <div class="site-branding">
             <div class="site-info">
                 <h1 class="site-title">
-                    <a href="/" rel="home">
+                    <a href="/" class="u-url u-uid" rel="home">
                         {{ if not .Site.Params.show_profile_photo }}
                             {{ if .Site.Params.custom_avatar }}
-                            <img src="{{ .Site.Params.custom_avatar }}" alt="{{ .Site.Title }} logo" class="title-avatar" width="32" height="32">
+                            <img src="{{ .Site.Params.custom_avatar }}" alt="{{ .Site.Title }} logo" class="title-avatar u-photo" width="32" height="32">
                             {{ else if .Site.Author.avatar }}
-                            <img src="{{ .Site.Author.avatar }}" alt="{{ .Site.Title }} logo" class="title-avatar" width="32" height="32">
+                            <img src="{{ .Site.Author.avatar }}" alt="{{ .Site.Title }} logo" class="title-avatar u-photo" width="32" height="32">
                             {{ end }}
                         {{ end }}
                         {{ .Site.Title }}
@@ -82,7 +82,7 @@
                     {{ if gt (len $socialLinks) 0 }}
                     <div class="social-icons" role="group" aria-label="Social media links">
                         {{ range $socialLinks }}
-                        <a href="{{ .url }}" class="social-link" aria-label="{{ .label }}" target="_blank" rel="noopener noreferrer">
+                        <a href="{{ .url }}" class="social-link u-url" aria-label="{{ .label }}" target="_blank" rel="noopener noreferrer me">
                             <i class="{{ .icon }}" aria-hidden="true"></i>
                         </a>
                         {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
         <div class="site-branding">
             <div class="site-info">
                 <h1 class="site-title">
-                    <a href="/" class="u-url u-uid" rel="home">
+                    <a href="/" class="u-url" rel="home">
                         {{ if not .Site.Params.show_profile_photo }}
                             {{ if .Site.Params.custom_avatar }}
                             <img src="{{ .Site.Params.custom_avatar }}" alt="{{ .Site.Title }} logo" class="title-avatar u-photo" width="32" height="32">
@@ -11,7 +11,7 @@
                             <img src="{{ .Site.Author.avatar }}" alt="{{ .Site.Title }} logo" class="title-avatar u-photo" width="32" height="32">
                             {{ end }}
                         {{ end }}
-                        {{ .Site.Title }}
+                        <span class="p-name">{{ .Site.Title }}</span>
                     </a>
                 </h1>
             </div>


### PR DESCRIPTION
## What does this PR do?
Add h-card microformats to header. Specifically, `u-url`, `u-photo`, `p-name`, and `rel=me` on social links

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Translation update
- [ ] Other (please describe)

## Testing
- [x] Tested on a Micro.blog site
- [ ] Checked that plugin.json is valid
- [x] Verified changes work across different browsers - https://indiewebify.me/validate-h-card/
- [ ] Screenshots included (if visual changes)

## For translation updates:
- [ ] All required translation keys are included
- [ ] Translations follow existing format/style

## Checklist
- [ ] Changes are backwards compatible
- [ ] No external resources added without consideration
- [ ] Code follows existing style in the theme