### PR TITLE
Fix GitHub link for Mythos Theme in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
             {{ if not .Site.Params.hide_footer_credits }}
             <p class="powered-by">
                 {{ T "PoweredBy" }} <a href="https://micro.blog" rel="nofollow">Micro.blog</a> + 
-                <a href="https://github.com/mattlangford/mythos-theme" rel="nofollow">Mythos Theme</a>.
+                <a href="https://github.com/MattSLangford/Mythos-Theme" rel="nofollow">Mythos Theme</a>.
                 <br>
                 {{ T "DesignedBy" }} <a href="https://mattlangford.com" rel="nofollow">Matt Langford</a>.
             </p>


### PR DESCRIPTION
Missing an S there, @MattSLangford :)